### PR TITLE
(hopefully) fixed a code bug.

### DIFF
--- a/content/program/workshops/hplan.md
+++ b/content/program/workshops/hplan.md
@@ -137,6 +137,7 @@ The following publications will be excluded from the proceedings to preven copyr
 
 
 <br>
+
 ## Workshop Schedule
 
 If you are interested in presenting work on hierarchical planning that was accepted or published at some other conference or journal (to promote your work to the hierarchical planning community), please contact the organizers. We will not include such a paper into our proceedings, but we are happy to discuss options for presenting such work. 


### PR DESCRIPTION
THe previous code was:
<br>
## Workshop Schedule

This lead to the line above not being rendered as a headline, but instead the # characters were *shown* on the page. So I added a line between the <br> and the headline, hoping that fixes the rendering error.